### PR TITLE
Perf: Frontend-Paket F1-F5 (Startup-Freeze, Pan-Jank, Label-Cache)

### DIFF
--- a/js/map-features/map-features-labels.js
+++ b/js/map-features/map-features-labels.js
@@ -25,9 +25,11 @@ const MAP_LABEL_CANVAS_ALPHA = 1; // volle Deckkraft (die Weichheit kommt von de
 const _mapLabelTypeStyleCache = {};
 let _mapLabelMeasureCtx = null;
 // Gerenderte Label-Bilder cachen: identischer Text/Stil/Größe -> dasselbe data-URL, kein erneutes
-// toDataURL pro Zoom/Pan (Siedlungs-Labels können zahlreich sein). Einfache Kappung gegen Wildwuchs.
+// toDataURL pro Zoom/Pan (Siedlungs-Labels können zahlreich sein). LRU-Verdrängung (Treffer rücken in der
+// Map-Insertion-Order nach hinten) statt FIFO: beim Zoom-Pendeln zwischen zwei Stufen flogen sonst genau
+// die Bilder raus, die gleich wieder gebraucht werden. Limit deckt mehrere Zoomstufen × Halo-Varianten ab.
 const _mapLabelImageCache = new Map();
-const _MAP_LABEL_IMAGE_CACHE_MAX = 2000;
+const _MAP_LABEL_IMAGE_CACHE_MAX = 6000;
 
 // Halo-Stärke S (0..5) -> Glow-Parameter für renderMapLabelToImage. S<=0: kein Halo. Bis S=1 wächst die
 // Deckkraft (S=1 ~ bisheriger Siedlungslabel-Default, Alpha 0.85); über S=1 hinaus verbreitert sich die
@@ -102,6 +104,9 @@ function renderMapLabelToImage(text, fontSizePx, typeStyle, opts) {
 	const cacheKey = `${displayText}|${font}|${typeStyle.color}|${glow || ""}|${glowBlur}|${glowPasses}|${strokeWidth}|${letterSpacing}|${vAnchor}`;
 	const cached = _mapLabelImageCache.get(cacheKey);
 	if (cached) {
+		// LRU: Treffer ans Ende der Insertion-Order verschieben -> Verdrängung trifft den ältesten UNGENUTZTEN Eintrag.
+		_mapLabelImageCache.delete(cacheKey);
+		_mapLabelImageCache.set(cacheKey, cached);
 		return cached;
 	}
 

--- a/js/map-features/map-features-location-marker-entry.js
+++ b/js/map-features/map-features-location-marker-entry.js
@@ -59,8 +59,11 @@ function refreshLocationMarkerPopup(markerEntry) {
 	const hasWikiSettlement = markerEntry.locationType !== CROSSING_LOCATION_TYPE
 		&& Boolean(markerEntry.location.wikiSettlement && markerEntry.location.wikiSettlement.title);
 	const maxHeight = locationMarkerPopupMaxHeight();
+	// Popup-Inhalt LAZY binden (Leaflet akzeptiert eine Content-Funktion): das HTML entsteht erst beim
+	// Öffnen. Vorher wurde es hier für JEDEN Marker beim Start gebaut (~3000 × Infobox/Buttons/Bewertungs-
+	// Markup) und beim Öffnen via popupopen ohnehin neu gesetzt -> reiner Startup-Ballast.
 	markerEntry.marker.bindPopup(
-		buildLocationMarkerPopupHtml(markerEntry),
+		() => buildLocationMarkerPopupHtml(markerEntry),
 		hasWikiSettlement
 			? { minWidth: 320, maxWidth: 400, maxHeight, className: "settlement-popup" }
 			: { maxHeight }

--- a/js/map-features/map-features-location-marker-rendering.js
+++ b/js/map-features/map-features-location-marker-rendering.js
@@ -154,7 +154,26 @@ function createLocationMarkerIcon(locationType, zoomLevel = map.getZoom()) {
 	});
 }
 
-function shouldShowLocationMarker(entry, zoomLevel = map.getZoom(), renderBounds = getMapRenderBounds()) {
+// Pro Sync-Lauf konstante Sichtbarkeits-Eingaben EINMAL erheben: Modus-Select, Größen-Toggles und
+// Editmode-Checkboxen sind für alle ~3000 Marker identisch, wurden aber pro Marker per jQuery abgefragt
+// (~6000 DOM-Queries pro moveend). Die Typ-Sichtbarkeit füllt sich lazy, weil die Typ-Liste hier nicht
+// bekannt sein muss. shouldShowLocationMarker/-NameLabel funktionieren auch OHNE Kontext (Einzelaufrufe).
+function createLocationVisibilityContext() {
+	const visibleTypeCache = {};
+	return {
+		mapLayerMode: typeof getSelectedMapLayerMode === "function" ? getSelectedMapLayerMode() : "",
+		nodixToggleChecked: IS_EDIT_MODE && $("#toggleNodix").is(":checked"),
+		crossingsToggleChecked: IS_EDIT_MODE && $("#toggleCrossings").is(":checked"),
+		isTypeVisible(locationType) {
+			if (!(locationType in visibleTypeCache)) {
+				visibleTypeCache[locationType] = isLocationTypeVisible(locationType);
+			}
+			return visibleTypeCache[locationType];
+		},
+	};
+}
+
+function shouldShowLocationMarker(entry, zoomLevel = map.getZoom(), renderBounds = getMapRenderBounds(), visibilityContext = null) {
 	// Per "Nächsten Ort finden"/Suche temporaer angepinnter Marker bleibt sichtbar, auch wenn seine
 	// Ortsgroesse nicht eingeblendet ist — bis die zugehoerige Infobox geschlossen wird.
 	if (typeof nearestLookupPinnedMarkerEntry !== "undefined" && entry === nearestLookupPinnedMarkerEntry) {
@@ -165,18 +184,26 @@ function shouldShowLocationMarker(entry, zoomLevel = map.getZoom(), renderBounds
 		return true;
 	}
 	if (entry.locationType === CROSSING_LOCATION_TYPE) {
-		return IS_EDIT_MODE
-			&& $("#toggleCrossings").is(":checked")
+		const crossingsToggleChecked = visibilityContext
+			? visibilityContext.crossingsToggleChecked
+			: IS_EDIT_MODE && $("#toggleCrossings").is(":checked");
+		return crossingsToggleChecked
 			&& zoomLevel >= 3
 			&& isMarkerEntryInRenderBounds(entry, renderBounds);
 	}
 
 	// Kraftlinien-Modus: NUR Nodices zeigen -- unabhängig von den Stadt-Größen-Toggles und vom Zoom (auch im Editmode).
-	if (typeof getSelectedMapLayerMode === "function" && getSelectedMapLayerMode() === "powerlines") {
+	const mapLayerMode = visibilityContext
+		? visibilityContext.mapLayerMode
+		: (typeof getSelectedMapLayerMode === "function" ? getSelectedMapLayerMode() : "");
+	if (mapLayerMode === "powerlines") {
 		return isNodixLocation(entry.location) && isMarkerEntryInRenderBounds(entry, renderBounds);
 	}
 
-	const isVisibleByNodixToggle = IS_EDIT_MODE && $("#toggleNodix").is(":checked") && isNodixLocation(entry.location);
+	const nodixToggleChecked = visibilityContext
+		? visibilityContext.nodixToggleChecked
+		: IS_EDIT_MODE && $("#toggleNodix").is(":checked");
+	const isVisibleByNodixToggle = nodixToggleChecked && isNodixLocation(entry.location);
 	const minZoomByType = entry.locationType === "kleinstadt"
 		? 1
 		: entry.locationType === "dorf"
@@ -184,7 +211,10 @@ function shouldShowLocationMarker(entry, zoomLevel = map.getZoom(), renderBounds
 			: entry.locationType === "gebaeude"
 				? 3
 				: 0;
-	return (isVisibleByNodixToggle || isLocationTypeVisible(entry.locationType))
+	const typeVisible = visibilityContext
+		? visibilityContext.isTypeVisible(entry.locationType)
+		: isLocationTypeVisible(entry.locationType);
+	return (isVisibleByNodixToggle || typeVisible)
 		&& zoomLevel >= minZoomByType
 		&& isMarkerEntryInRenderBounds(entry, renderBounds);
 }
@@ -193,6 +223,7 @@ function syncLocationMarkerVisibility() {
 	syncLocationToggleButtons();
 	const zoomLevel = map.getZoom();
 	const renderBounds = getMapRenderBounds();
+	const visibilityContext = createLocationVisibilityContext();
 	// EXPERIMENTELL (Flag ?canvasmarkers=1, default AUS): dorf+kleinstadt ausserhalb Edit -> Canvas.
 	const canvasOn = typeof LOCATION_CANVAS_MARKERS_ENABLED !== "undefined" && LOCATION_CANVAS_MARKERS_ENABLED && !IS_EDIT_MODE;
 	if (canvasOn) {
@@ -200,7 +231,7 @@ function syncLocationMarkerVisibility() {
 	}
 	const canvasEntries = [];
 	$.each(locationMarkers, (i, entry) => {
-		const shouldShow = shouldShowLocationMarker(entry, zoomLevel, renderBounds);
+		const shouldShow = shouldShowLocationMarker(entry, zoomLevel, renderBounds, visibilityContext);
 		const canvasEligible = canvasOn
 			&& shouldShow
 			&& LOCATION_CANVAS_TYPES.has(entry.locationType)
@@ -231,7 +262,7 @@ function syncLocationMarkerVisibility() {
 	if (canvasOn) {
 		locationCanvasLayer.setEntries(canvasEntries);
 	}
-	syncLocationNameLabelVisibility();
+	syncLocationNameLabelVisibility(visibilityContext);
 }
 
 function getMapRenderBounds() {

--- a/js/map-features/map-features-location-name-labels.js
+++ b/js/map-features/map-features-location-name-labels.js
@@ -33,23 +33,33 @@ function getLocationNameLabelOffset(labelSize, zoomLevel = map.getZoom(), locati
 	};
 }
 
-function shouldShowLocationNameLabel(entry, zoomLevel = map.getZoom()) {
+// visibilityContext (optional, siehe createLocationVisibilityContext): pro Sync-Lauf EINMAL erhobene
+// Invarianten (Modus, Toggles) statt jQuery-Abfragen pro Label — ohne Kontext bleibt das alte Verhalten.
+function shouldShowLocationNameLabel(entry, zoomLevel = map.getZoom(), visibilityContext = null) {
 	if (activeMapStyle !== "stylized" || isCrossingLocation(entry.location)) {
 		return false;
 	}
 
 	// Kraftlinien-Modus: nur die Nodices labeln (passend zu den leuchtenden Ley-Knoten), unabhängig von den
 	// Stadt-Größen-Toggles. Kollisionsauflösung dünnt die Namen bei niedrigem Zoom aus.
-	if (typeof getSelectedMapLayerMode === "function" && getSelectedMapLayerMode() === "powerlines") {
+	const mapLayerMode = visibilityContext
+		? visibilityContext.mapLayerMode
+		: (typeof getSelectedMapLayerMode === "function" ? getSelectedMapLayerMode() : "");
+	if (mapLayerMode === "powerlines") {
 		return isNodixLocation(entry.location);
 	}
 
 	const config = LOCATION_NAME_LABEL_CONFIG[entry.locationType] || LOCATION_NAME_LABEL_CONFIG.dorf;
-	const isVisibleByNodixToggle = IS_EDIT_MODE
-		&& $("#toggleNodix").is(":checked")
+	const nodixToggleChecked = visibilityContext
+		? visibilityContext.nodixToggleChecked
+		: IS_EDIT_MODE && $("#toggleNodix").is(":checked");
+	const isVisibleByNodixToggle = nodixToggleChecked
 		&& isNodixLocation(entry.location)
 		&& zoomLevel >= 2;
-	return isVisibleByNodixToggle || (zoomLevel >= config.minZoom && isLocationTypeVisible(entry.locationType));
+	const typeVisible = visibilityContext
+		? visibilityContext.isTypeVisible(entry.locationType)
+		: isLocationTypeVisible(entry.locationType);
+	return isVisibleByNodixToggle || (zoomLevel >= config.minZoom && typeVisible);
 }
 
 // Pro Orts-Label-Typ (+ Ruine) Farbe/Versalien/Kursiv/Sperrung EINMAL aus dem echten CSS lesen
@@ -118,8 +128,11 @@ function createLocationNameLabelIcon(entry, zoomLevel = map.getZoom()) {
 }
 
 function createLocationNameLabelEntry(markerEntry) {
+	// LAZY: Marker mit leerem Platzhalter-Icon anlegen — das echte Label-Bild (Canvas + toDataURL) rendert
+	// erst syncLocationNameLabelVisibility für SICHTBARE Labels. Vorher wurden hier beim Start alle ~3000
+	// Siedlungs-Labels gerastert (ein einzelner ~5s-Longtask), obwohl bei Zoom 0 nur ~40 sichtbar sind.
 	const marker = L.marker(markerEntry.location.coordinates, {
-		icon: createLocationNameLabelIcon(markerEntry),
+		icon: L.divIcon({ className: "location-name-label", html: "", iconSize: [0, 0], iconAnchor: [0, 0] }),
 		interactive: false,
 		keyboard: false,
 		pane: "labelsPane",
@@ -127,11 +140,21 @@ function createLocationNameLabelEntry(markerEntry) {
 	return { markerEntry, marker };
 }
 
-function syncLocationNameLabelVisibility() {
+// Stil-Revision der Siedlungs-Labels: zählt hoch, wenn sich das Label-AUSSEHEN global ändert (Halo-Slider
+// im ?halotune=1-Panel). Der setIcon-Guard in syncLocationNameLabelVisibility rendert ein Label nur neu,
+// wenn sich Zoom, Stil-Revision, Name oder Ruinen-Status seit dem letzten Bau geändert haben — beim reinen
+// Pannen bleibt das Icon stehen (kein DOM-Austausch von bis zu ~350 <img>-Icons pro moveend).
+let _locationNameLabelStyleRevision = 0;
+function bumpLocationNameLabelStyleRevision() {
+	_locationNameLabelStyleRevision += 1;
+}
+
+function syncLocationNameLabelVisibility(visibilityContext = null) {
 	const zoomLevel = map.getZoom();
 	const renderBounds = getMapRenderBounds();
+	const context = visibilityContext || createLocationVisibilityContext();
 	locationNameLabels.forEach((entry) => {
-		const shouldShow = shouldShowLocationNameLabel(entry.markerEntry, zoomLevel)
+		const shouldShow = shouldShowLocationNameLabel(entry.markerEntry, zoomLevel, context)
 			&& isMarkerEntryInRenderBounds(entry.markerEntry, renderBounds);
 		if (!shouldShow) {
 			map.removeLayer(entry.marker);
@@ -139,7 +162,11 @@ function syncLocationNameLabelVisibility() {
 		}
 
 		entry.marker.setLatLng(entry.markerEntry.marker.getLatLng());
-		entry.marker.setIcon(createLocationNameLabelIcon(entry.markerEntry, zoomLevel));
+		const iconKey = `${zoomLevel}|${_locationNameLabelStyleRevision}|${entry.markerEntry.name}|${entry.markerEntry.location?.isRuined ? "r" : ""}`;
+		if (entry._iconKey !== iconKey) {
+			entry.marker.setIcon(createLocationNameLabelIcon(entry.markerEntry, zoomLevel));
+			entry._iconKey = iconKey;
+		}
 		map.addLayer(entry.marker);
 	});
 	scheduleLabelCollisionResolution();
@@ -197,7 +224,8 @@ function removeLocationNameLabel(markerEntry) {
 		input.addEventListener("input", () => { const v = parseFloat(input.value); vl.textContent = String(v); apply(v); });
 		panel.appendChild(head); panel.appendChild(input);
 	};
-	const refreshSettlements = () => { try { if (typeof syncLocationNameLabelVisibility === "function") syncLocationNameLabelVisibility(); } catch (e) { /* noop */ } };
+	// Stil-Revision hochzählen, sonst überspringt der setIcon-Guard im Sync das Neu-Rendern der Labels.
+	const refreshSettlements = () => { try { bumpLocationNameLabelStyleRevision(); if (typeof syncLocationNameLabelVisibility === "function") syncLocationNameLabelVisibility(); } catch (e) { /* noop */ } };
 	const refreshRegions = () => { try { if (typeof syncLabelIcons === "function") syncLabelIcons(); } catch (e) { /* noop */ } };
 	addSlider("Siedlungen Stärke", () => LOCATION_LABEL_HALO_STRENGTH, (v) => { LOCATION_LABEL_HALO_STRENGTH = v; refreshSettlements(); });
 	addSlider("Siedlungen Schärfe", () => LOCATION_LABEL_HALO_SHARPNESS, (v) => { LOCATION_LABEL_HALO_SHARPNESS = v; refreshSettlements(); }, 0, 1, 0.05);


### PR DESCRIPTION
## Was

Frontend-Performance-Paket F1–F5 aus der Hotpath-Analyse vom 10.06. Vier Dateien, ~90 Zeilen, keine Verhaltensänderung.

| # | Fix | Stelle |
|---|---|---|
| F1 | Label-Icons lazy: Platzhalter-Icon beim Anlegen, das echte Canvas-Bild rendert erst der Sichtbarkeits-Sync für sichtbare Labels (vorher: alle ~3000 beim Start gerastert, ~40 sichtbar) | map-features-location-name-labels.js |
| F2 | Popup-HTML lazy: bindPopup mit Content-Funktion statt vorgebautem Markup (popupopen baute den Inhalt ohnehin neu) | map-features-location-marker-entry.js |
| F3 | Sync-Invarianten (Modus-Select, Größen-Toggles, Editmode-Checkboxen) EINMAL pro Sync-Lauf erheben statt per jQuery pro Marker (~6000 DOM-Queries pro moveend). shouldShow*-Signaturen rückwärtskompatibel | map-features-location-marker-rendering.js, -name-labels.js |
| F4 | setIcon-Guard für Siedlungs-Labels analog zum vorhandenen Marker-Guard: Neu-Rendern nur bei geändertem Zoom/Stil/Name/Ruinen-Status; die ?halotune=1-Slider zählen eine Stil-Revision hoch | map-features-location-name-labels.js |
| F5 | Label-Bild-Cache: LRU statt FIFO, Limit 2000 → 6000 | map-features-labels.js |

## Messung (lokales Bench-Rig, 6.403 Features, Chrome)

| Metrik | Vorher (master) | Nachher (Branch) |
|---|---|---|
| Startup-Block nach Datenladen | **ein 5.330-ms-Longtask** | **0 Longtasks** |
| moveend-Handler (Pan, synchron, 12 Messungen) | Ø 166 ms (128–215) | **Ø 80 ms (61–127)** |
| JS-Heap nach Start | ~174 MB | ~74 MB |
| Zoomstufen-Wechsel (Erstbesuch) | 0,76–1,19 s | unverändert 0,67–1,5 s |

Der Zoom-Freeze beim ERSTEN Besuch einer Stufe bleibt — er ist nicht Raster-, sondern DOM-dominiert (Marker-/Label-setIcon-Austausch + Pfad-Styling). Folge-Arbeit dafür: Label-/Marker-Skalierung per CSS-Transform statt Icon-Neubau.

## Messmethodik / Reproduktion

Statische API-Mocks aus der Git-History (`git show 477cf7ad^:map/Aventurien_routes.geojson`, `git show 03bb40cf^:layer0.json`), Kopie von index.html mit `window.AVESMAPS_*_ENDPOINT`-Overrides vor dem ersten Script-Tag, lokaler Server. Zoom/Pan synchron via `setZoom/panBy({animate:false})` + `performance.now()` (zoomend/moveend feuern synchron), Startup via gebuffertem Longtask-Observer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)