### PR TITLE
fix(route): waypoint icons only on real waypoints (Bug #10) + audit follow-ups

### DIFF
--- a/api/edit/reports/locations.php
+++ b/api/edit/reports/locations.php
@@ -57,6 +57,7 @@ function avesmapsListLocationReportsForReview(PDO $pdo): array {
             report_type,
             report_subtype,
             name,
+            reporter_name,
             lat,
             lng,
             source,

--- a/css/features/location-popups-markers.css
+++ b/css/features/location-popups-markers.css
@@ -77,28 +77,22 @@
 /* Der weisse "Karten"-Grund ist .leaflet-popup-content-wrapper; die Basis-Regel oben zieht
    .leaflet-popup-content 10px ein. Fuer randlose Trenner (wie beim settlement-popup) den Content-Margin
    nullen -> .location-popup sitzt buendig, die -10px-Offsets unten erreichen die echte Kartenkante. */
-.slim-location-popup .leaflet-popup-content,
-.waypoint-hover-popup .leaflet-popup-content {
+.slim-location-popup .leaflet-popup-content {
 	margin: 0;
 }
-/* Schlanke Karten-Popups (find-nearest + Wegpunkt-Hover): JEDER Trenner geht IMMER randlos von Rand
-   zu Rand durch (Owner-Regel: nie kurz stoppen). Genau EINE Linie je Section-Grenze -- der Kopf-Trenner
-   unter Name/Typ (Builder rendert ihn nur bei vorhandener Beschreibung) sowie je eine Linie ueber
-   Quelle und Aktionen. Offset -10px = das horizontale Content-Padding der .location-popup. So sieht
-   die Box aus wie das normale settlement-popup (dort -14px bei 14px Padding). */
+/* Schlanke Karten-Popups (find-nearest): JEDER Trenner geht IMMER randlos von Rand zu Rand durch
+   (Owner-Regel: nie kurz stoppen). Genau EINE Linie je Section-Grenze -- der Kopf-Trenner unter
+   Name/Typ (Builder rendert ihn nur bei vorhandener Beschreibung) sowie je eine Linie ueber Quelle und
+   Aktionen. Offset -10px = das horizontale Content-Padding der .location-popup. So sieht die Box aus wie
+   das normale settlement-popup (dort -14px bei 14px Padding). */
 .slim-location-popup .location-popup__divider,
-.waypoint-hover-popup .location-popup__divider,
 .slim-location-popup .feature-sources,
-.waypoint-hover-popup .feature-sources,
-.slim-location-popup .location-popup__actions,
-.waypoint-hover-popup .location-popup__actions {
+.slim-location-popup .location-popup__actions {
 	margin-left: -10px;
 	margin-right: -10px;
 }
 .slim-location-popup .feature-sources,
-.waypoint-hover-popup .feature-sources,
-.slim-location-popup .location-popup__actions,
-.waypoint-hover-popup .location-popup__actions {
+.slim-location-popup .location-popup__actions {
 	margin-top: 10px;
 	padding-top: 10px;
 	padding-left: 10px;

--- a/js/review/review-editor-submit.js
+++ b/js/review/review-editor-submit.js
@@ -35,22 +35,35 @@ async function handleLocationEditFormSubmit(event) {
 		} else {
 			savedMarkerEntry = addCreatedLocationMarker(responseFeature);
 		}
-		// Auto-connect / re-connect the wiki settlement from the place's wiki link (e.g. inherited from a
-		// community report), so a save with a wiki URL links its {{Infobox Siedlung}} data without a manual
-		// "Zuweisen". Runs when the URL resolves to a settlement title that DIFFERS from the one currently
-		// connected -- a brand-new place (nothing connected) OR a corrected URL on an already-connected place
-		// (owner: a changed source must be taken over). It stays off when the URL already matches the
-		// connection (nothing to do); and a manual "Verbindung entfernen" clears the wiki_url field
-		// (removeSettlementWiki), so an unrelated later save does NOT silently re-attach the removed link.
+		// Auto-connect the place to its wiki settlement so a save attaches the {{Infobox Siedlung}} data
+		// without a manual "Zuweisen". Two paths, in order:
+		//  1) By wiki_url (e.g. inherited from a community report): runs when the URL resolves to a
+		//     settlement title DIFFERENT from the one currently connected -- a brand-new place OR a
+		//     corrected URL on an already-connected one (owner: a changed source must be taken over).
+		//     Stays off when the URL already matches; a manual "Verbindung entfernen" clears the wiki_url
+		//     field (removeSettlementWiki) so an unrelated later save does not silently re-attach it.
+		//  2) By NAME (owner): community reports usually carry only a book source, no wiki link -> path 1
+		//     never fires. When a place is freshly created with NO wiki_url and NOTHING connected yet but
+		//     its name matches a wiki settlement exactly, connect via the name. The server only matches a
+		//     page titled exactly like the place (no fuzzy match), so "Wengenholm 2" stays unconnected.
+		// A failed URL attempt is surfaced (not silent) so the editor knows to assign manually; a failed
+		// name attempt stays quiet (most places have no same-named wiki page -- that is not an error).
 		const connectedWikiTitle = savedMarkerEntry && savedMarkerEntry.location && savedMarkerEntry.location.wikiSettlement
 			? String(savedMarkerEntry.location.wikiSettlement.title || "")
 			: "";
 		const desiredWikiTitle = typeof settlementWikiTitleFromUrl === "function"
 			? settlementWikiTitleFromUrl(payload.wiki_url)
 			: "";
-		if (desiredWikiTitle && desiredWikiTitle !== connectedWikiTitle && savedMarkerEntry
+		const connectPublicId = savedMarkerEntry?.publicId || savedMarkerEntry?.location?.publicId || responseFeature?.public_id || "";
+		if (desiredWikiTitle && desiredWikiTitle !== connectedWikiTitle && connectPublicId
 			&& typeof autoConnectSettlementWikiByUrl === "function") {
-			await autoConnectSettlementWikiByUrl(savedMarkerEntry.publicId || responseFeature?.public_id || "", payload.wiki_url, savedMarkerEntry);
+			const connected = await autoConnectSettlementWikiByUrl(connectPublicId, payload.wiki_url, savedMarkerEntry);
+			if (!connected) {
+				showFeedbackToast?.(`Wiki-Siedlung „${desiredWikiTitle}" konnte nicht automatisch verbunden werden – bitte manuell „Zuweisen".`, "warning");
+			}
+		} else if (!desiredWikiTitle && !connectedWikiTitle && payload.action === "create_point" && payload.name && connectPublicId
+			&& typeof autoConnectSettlementWikiByTitle === "function") {
+			await autoConnectSettlementWikiByTitle(connectPublicId, payload.name, savedMarkerEntry);
 		}
 		if (payload.action === "create_point" && activeReviewReportId) {
 			await updateReviewReportStatus(activeReviewReportId, "approved", activeReviewReportSource || "location_reports");

--- a/js/review/review-panels.js
+++ b/js/review/review-panels.js
@@ -174,7 +174,14 @@ function renderReviewReports() {
 		`;
 		itemElement.querySelector(".review-report__name").textContent = report.name || "Unbenannter Eintrag";
 		itemElement.querySelector(".review-report__meta").textContent = `${getReportTypeLabel(report)} · ${formatLocationReportCoordinates(L.latLng(Number(report.lat), Number(report.lng)))}`;
-		itemElement.querySelector(".review-report__source").textContent = report.source || "Keine Quelle";
+		const reportSourceParts = [report.source || "Keine Quelle"];
+		if (report.reporter_name) {
+			reportSourceParts.push(`gemeldet von ${report.reporter_name}`);
+		}
+		if (report.wiki_url) {
+			reportSourceParts.push("Wiki-Link vorhanden");
+		}
+		itemElement.querySelector(".review-report__source").textContent = reportSourceParts.join(" · ");
 		if (isCommentReport(report)) {
 			itemElement.querySelector(".review-report__create").textContent = "Erledigt";
 		}

--- a/js/review/review-settlement-wiki.js
+++ b/js/review/review-settlement-wiki.js
@@ -229,13 +229,11 @@ function settlementWikiTitleFromUrl(wikiUrl) {
 	}
 }
 
-// Auto-connect a place to its wiki settlement straight from its wiki URL (e.g. one inherited from a
-// community report), so a save with a wiki link attaches the {{Infobox Siedlung}} data without a
-// manual "Zuweisen". Best-effort: does nothing when the URL carries no title or assign_to fails, so
-// a save is never blocked. Updates the marker's cached wikiSettlement + revision so the popup shows
-// the connection immediately and the next save's expected_revision still matches.
-async function autoConnectSettlementWikiByUrl(publicId, wikiUrl, markerEntry) {
-	const title = settlementWikiTitleFromUrl(wikiUrl);
+// Core: connect ONE place feature to its wiki settlement by the settlement's exact TITLE (assign_to).
+// Best-effort: returns false when publicId/title is missing or the server finds no {{Infobox Siedlung}}
+// under that title -- never blocks a save. Updates the cached wikiSettlement + revision so the popup
+// shows the connection immediately and the next save's expected_revision still matches.
+async function autoConnectSettlementWikiByTitle(publicId, title, markerEntry) {
 	if (!publicId || !title) {
 		return false;
 	}
@@ -260,6 +258,13 @@ async function autoConnectSettlementWikiByUrl(publicId, wikiUrl, markerEntry) {
 	} catch (error) {
 		return false;
 	}
+}
+
+// Convenience: connect a place to its wiki settlement straight from its wiki URL (title derived from
+// /wiki/<Title>, e.g. one inherited from a community report), so a save with a wiki link attaches the
+// {{Infobox Siedlung}} data without a manual "Zuweisen".
+async function autoConnectSettlementWikiByUrl(publicId, wikiUrl, markerEntry) {
+	return autoConnectSettlementWikiByTitle(publicId, settlementWikiTitleFromUrl(wikiUrl), markerEntry);
 }
 
 async function removeSettlementWiki() {

--- a/js/routing/route-render.js
+++ b/js/routing/route-render.js
@@ -82,35 +82,36 @@ function bindWaypointHoverPopup(marker, markerEntry) {
 	marker.on("mouseout", scheduleClose);
 }
 
+// Owner-Vorgabe (Bug #10): NUR die echten, vom Nutzer gesetzten Wegpunkte bekommen ein Icon -- NICHT
+// jede Kreuzung oder jeder Durchgangsort der berechneten Route. routeNames ist die KOMPLETTE
+// Graph-Knotenliste (Start/Ziel + alle Kreuzungen + Durchgangsorte, mit Duplikaten an den
+// Segmentgrenzen); ueber sie zu iterieren setzte fruerher ein 28px-Icon auf jeden Knoten. Die echten
+// Wegpunkte stehen in selectedLocations (an allen Aufrufstellen direkt zuvor via
+// collectAndValidateSelectedLocations gefuellt, unveraendert bis hierher). Der letzte Wegpunkt ist das
+// Ziel (pin.webp), alle uebrigen sind waypoint.webp. routeNames/segments werden fuer die Icon-Auswahl
+// nicht mehr gebraucht, bleiben aber in der Signatur (feste Aufrufer-Kette).
 function highlightRouteLocations(routeNames, segments = []) {
 	removeHighlightedRouteNodes();
 	const icons = waypointRouteIcons();
-	routeNames.forEach((name, index) => {
-		const previousIsSea = normalizePathSubtype(segments[index - 1]?.properties?.feature_subtype || segments[index - 1]?.properties?.name) === "Seeweg";
-		const nextIsSea = normalizePathSubtype(segments[index]?.properties?.feature_subtype || segments[index]?.properties?.name) === "Seeweg";
-		const loc = resolveRouteNodeLocation(name, index, routeNames, segments);
-		if ((previousIsSea || nextIsSea) && (!loc || isCrossingLocation(loc))) {
+	const waypoints = Array.isArray(selectedLocations) ? selectedLocations : [];
+	waypoints.forEach((waypoint, index) => {
+		if (!waypoint || !waypoint.coordinates) {
 			return;
 		}
-
-		if (loc) {
-			// Einzelner Wegpunkt -> waypoint.webp; letzter (Ziel) -> pin.webp.
-			const isDestination = index === routeNames.length - 1;
-			const markerEntry = typeof findLocationMarkerByName === "function" ? findLocationMarkerByName(name) : null;
-			const node = L.marker(loc.coordinates, {
-				icon: isDestination ? icons.pin : icons.waypoint,
-				interactive: true,
-				keyboard: false,
-				zIndexOffset: 600,
-			}).addTo(map);
-			// Hover-Infobox nur, wenn der Wegpunkt ein geladener Ort ist (Kreuzungen bleiben ohne Popup).
-			if (markerEntry) {
-				bindWaypointHoverPopup(node, markerEntry);
-			}
-			highlightedRouteNodes.push(node);
-		} else {
-			console.warn(`Location ${name} nicht gefunden.`);
+		// Einzelner Wegpunkt -> waypoint.webp; letzter (Ziel) -> pin.webp.
+		const isDestination = index === waypoints.length - 1;
+		const markerEntry = typeof findLocationMarkerByName === "function" ? findLocationMarkerByName(waypoint.name) : null;
+		const node = L.marker(waypoint.coordinates, {
+			icon: isDestination ? icons.pin : icons.waypoint,
+			interactive: true,
+			keyboard: false,
+			zIndexOffset: 600,
+		}).addTo(map);
+		// Hover-Infobox nur, wenn der Wegpunkt ein geladener Ort ist (Kartenpunkte bleiben ohne Popup).
+		if (markerEntry) {
+			bindWaypointHoverPopup(node, markerEntry);
 		}
+		highlightedRouteNodes.push(node);
 	});
 }
 

--- a/js/routing/route-render.js
+++ b/js/routing/route-render.js
@@ -43,74 +43,21 @@ function logRoutePoints(segments) {
 	return points;
 }
 
-// Wegpunkt-Grafiken (Owner-Vorgabe): einzelne Wegpunkte -> waypoint.webp (zentriert auf den Vertex),
-// das Ziel (letzter Wegpunkt) -> pin.webp (Spitze unten auf den Vertex). Lazy erzeugt (map/L existieren).
-let waypointRouteIconCache = null;
-function waypointRouteIcons() {
-	if (!waypointRouteIconCache) {
-		waypointRouteIconCache = {
-			waypoint: L.icon({ iconUrl: "icons/waypoint.webp", iconSize: [28, 28], iconAnchor: [14, 14], className: "route-waypoint-icon" }),
-			pin: L.icon({ iconUrl: "icons/pin.webp", iconSize: [30, 37], iconAnchor: [15, 37], className: "route-waypoint-pin" }),
-		};
-	}
-	return waypointRouteIconCache;
-}
-
-// Hover-Popup an einem Wegpunkt-Icon: zeigt die SCHLANKE Infobox (buildSlimLocationPopupHtml). Owner:
-// beim Hovern erscheint die Infobox und BLEIBT, solange die Maus ueber Icon ODER Popup ist (Buttons
-// klickbar). Kein Auto-Popup beim Klick -> nur Hover. Die Vollansicht bleibt dem rechten Panel vorbehalten.
-function bindWaypointHoverPopup(marker, markerEntry) {
-	if (typeof buildSlimLocationPopupHtml !== "function") {
-		return;
-	}
-	let closeTimer = null;
-	const popup = L.popup({ autoClose: false, closeOnClick: false, closeButton: false, className: "waypoint-hover-popup", maxWidth: 300, offset: [0, -8] });
-	const cancelClose = () => { if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; } };
-	const scheduleClose = () => { cancelClose(); closeTimer = setTimeout(() => map.closePopup(popup), 220); };
-	const openHover = () => {
-		cancelClose();
-		popup.setLatLng(marker.getLatLng());
-		popup.setContent(buildSlimLocationPopupHtml(markerEntry));
-		map.openPopup(popup);
-		const el = typeof popup.getElement === "function" ? popup.getElement() : popup._container;
-		if (el) {
-			el.addEventListener("mouseenter", cancelClose);
-			el.addEventListener("mouseleave", scheduleClose);
-		}
-	};
-	marker.on("mouseover", openHover);
-	marker.on("mouseout", scheduleClose);
-}
-
-// Owner-Vorgabe (Bug #10): NUR die echten, vom Nutzer gesetzten Wegpunkte bekommen ein Icon -- NICHT
-// jede Kreuzung oder jeder Durchgangsort der berechneten Route. routeNames ist die KOMPLETTE
-// Graph-Knotenliste (Start/Ziel + alle Kreuzungen + Durchgangsorte, mit Duplikaten an den
-// Segmentgrenzen); ueber sie zu iterieren setzte fruerher ein 28px-Icon auf jeden Knoten. Die echten
-// Wegpunkte stehen in selectedLocations (an allen Aufrufstellen direkt zuvor via
-// collectAndValidateSelectedLocations gefuellt, unveraendert bis hierher). Der letzte Wegpunkt ist das
-// Ziel (pin.webp), alle uebrigen sind waypoint.webp. routeNames/segments werden fuer die Icon-Auswahl
-// nicht mehr gebraucht, bleiben aber in der Signatur (feste Aufrufer-Kette).
+// Wegpunkt-Markierung: NUR die echten, vom Nutzer gesetzten Wegpunkte (selectedLocations) bekommen einen
+// dezenten Punkt -- NICHT jede Kreuzung/jeder Durchgangsort der berechneten Route (Bug #10). Die
+// waypoint.webp/pin.webp-Grafik (fbb5565b) ist wieder raus (Owner: renderte falsch + unruhige Optik);
+// zurueck zum schlichten circleMarker (ROUTE_NODE_STYLE) wie vor dem Icon-Feature. selectedLocations ist
+// an allen Aufrufstellen direkt zuvor via collectAndValidateSelectedLocations gefuellt (unveraendert bis
+// hierher); routeNames/segments bleiben in der Signatur (feste Aufrufer-Kette), steuern die Markierung
+// aber nicht mehr (die komplette Knotenliste enthaelt Kreuzungen + Duplikate).
 function highlightRouteLocations(routeNames, segments = []) {
 	removeHighlightedRouteNodes();
-	const icons = waypointRouteIcons();
 	const waypoints = Array.isArray(selectedLocations) ? selectedLocations : [];
-	waypoints.forEach((waypoint, index) => {
+	waypoints.forEach((waypoint) => {
 		if (!waypoint || !waypoint.coordinates) {
 			return;
 		}
-		// Einzelner Wegpunkt -> waypoint.webp; letzter (Ziel) -> pin.webp.
-		const isDestination = index === waypoints.length - 1;
-		const markerEntry = typeof findLocationMarkerByName === "function" ? findLocationMarkerByName(waypoint.name) : null;
-		const node = L.marker(waypoint.coordinates, {
-			icon: isDestination ? icons.pin : icons.waypoint,
-			interactive: true,
-			keyboard: false,
-			zIndexOffset: 600,
-		}).addTo(map);
-		// Hover-Infobox nur, wenn der Wegpunkt ein geladener Ort ist (Kartenpunkte bleiben ohne Popup).
-		if (markerEntry) {
-			bindWaypointHoverPopup(node, markerEntry);
-		}
+		const node = L.circleMarker(waypoint.coordinates, ROUTE_NODE_STYLE).addTo(map);
 		highlightedRouteNodes.push(node);
 	});
 }


### PR DESCRIPTION
Isolated worktree branch for the open technical bugs from the adversarial audit. Kept off `master` so it does not collide with the parallel design session's unpushed commits.

## ✅ Route waypoint markers — icons removed, back to dezente dots (Bug #10 + owner rollback)

Two commits, in order:

1. **`fix(route)` — Bug #10 scope.** `highlightRouteLocations` iterated over `routeNodeNames` (the complete graph node list: start/end + every crossing + every pass-through place, with duplicates) and dropped a marker on each. On Gareth → Havena that was 39 markers (14 on crossings) for 2 user waypoints. Fixed to iterate over `selectedLocations` (the real, user-set waypoints).

2. **`ui(route)` — remove the `waypoint.webp`/`pin.webp` graphic.** Owner: the icon graphics (introduced yesterday in `fbb5565b`) render wrong and look bad. Rolled back to the schlichte `circleMarker` (`ROUTE_NODE_STYLE`) the route nodes had before the icon feature — keeping the Bug #10 scope (only real waypoints). Removed the icon infrastructure (`waypointRouteIcons`, `bindWaypointHoverPopup`) and the now-orphaned `.waypoint-hover-popup` CSS (its rules were shared with the still-used `.slim-location-popup` find-nearest box, so only the waypoint selectors were dropped).

**Net result:** each real waypoint gets one small `circleMarker` dot (r=6); crossings and pass-through nodes get nothing; no `waypoint.webp`/`pin.webp` anywhere. Verified live: 2 waypoints → 2 dots, 0 image markers; `node --check` clean; no orphaned references.

## 🔍 Wengenholm wiki auto-connect — VERIFICATION (blocked on 1 owner datapoint)

Checked whether the `323fb0bd` auto-connect fix hits the real "community report → edit source" scenario. Owner confirms the symptom: **no wiki settlement gets connected after saving**.

- ✅ Client title extraction works (`settlementWikiTitleFromUrl(".../wiki/Wengenholm")` → `"Wengenholm"`).
- ✅ Server path sound: `AVESMAPS_WIKI_API_URL` correct (`/de/api.php`), `buildFromTitle` fetches live wikitext keyed by requested title (redirects handled), `parseInfobox` never throws → `assign_to("Wengenholm")` *should* succeed (the wiki page really is a `{{Infobox Siedlung}}`).
- ⚠️ Most likely root cause is client-side: the report carried **no `wiki_url`** (mandatory `source` field holds a book source; `wiki_url` optional and empty) → `desiredWikiTitle=""` → auto-connect never fires.
- ⚠️ Auto-connect failure is **silent** — `autoConnectSettlementWikiByUrl`'s return value is ignored in `review-editor-submit.js`.

Awaiting the owner's `preview?title=Wengenholm` + hidden-`wiki_url`-field diagnostic to fix precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)