### PR TITLE
ui(infopanel): [Link teilen] [Änderung vorschlagen] together under the header

### DIFF
--- a/js/map-features/map-features-infopanel.js
+++ b/js/map-features/map-features-infopanel.js
@@ -601,7 +601,9 @@
 		if (typeof buildTerritoryAdventuresMarkup === "function") {
 			markup += buildTerritoryAdventuresMarkup(regionEntry);
 		}
-		markup += regionSuggestChangeBandMarkup(regionEntry);
+		// Wiki-Regionen/Territorien tragen den Button jetzt im Kopf-Band (region-info-markup.js). Nur die
+		// kompakte Mini-Box (ohne Wiki, ohne Aktionsband) bekommt ihn hier unten angehaengt.
+		if (typeof hasRegionWikiInfo === "function" && !hasRegionWikiInfo(regionEntry)) { markup += regionSuggestChangeBandMarkup(regionEntry); }
 		return markup;
 	}
 

--- a/js/map-features/map-features-path-rendering.js
+++ b/js/map-features/map-features-path-rendering.js
@@ -35,17 +35,17 @@ function pathWikiInfoboxMarkup(path) {
 	);
 }
 
-// "Link teilen"-Leiste eines Weges -- separat, damit createPathPopupMarkup sie (Owner) direkt unter den
-// Kopf setzen kann statt ans Ende der Infobox. Nur bei verlinktem Wiki-Artikel (Wege sind nicht ueber
-// ?place= aufloesbar). wikiParam nach Subtyp: Fluss/Seeweg -> "fluss", sonst "strasse" (wiki-deeplink.js).
-function pathShareMarkup(path) {
+// "Link teilen"-Button eines Weges -- gehoert (Owner) in DASSELBE Kachelband wie "Änderung vorschlagen",
+// direkt unter dem Kopf (nicht als eigenes Band dahinter). Nur bei verlinktem Wiki-Artikel (Wege sind nicht
+// ueber ?place= aufloesbar). wikiParam nach Subtyp: Fluss/Seeweg -> "fluss", sonst "strasse" (wiki-deeplink.js).
+function pathShareButtonMarkup(path) {
 	const wiki = (path.properties && path.properties.wiki_path) || {};
 	if (!wiki.wiki_url) {
 		return "";
 	}
 	const pathSubtype = normalizePathSubtype(path.properties?.feature_subtype || path.properties?.name);
 	const wikiParam = (pathSubtype === "Flussweg" || pathSubtype === "Seeweg") ? "fluss" : "strasse";
-	return locationPopupActionsMarkup([sharePlaceActionButtonMarkup(getPathPublicId(path), { wikiUrl: wiki.wiki_url, wikiParam })]);
+	return sharePlaceActionButtonMarkup(getPathPublicId(path), { wikiUrl: wiki.wiki_url, wikiParam });
 }
 
 // Kopf-Icon fuer den Weg-Kopf (Owner: einheitlicher grosser Kopf -- Wege haben kein Wappen, bekommen
@@ -78,6 +78,9 @@ function createPathPopupMarkup(path) {
 		showType: true,
 		actionsMarkup: (function () {
 			const buttons = [];
+			// "Link teilen" zuerst -> [Link teilen] [Änderung vorschlagen] gemeinsam in EINEM Band unter dem Kopf.
+			const shareButton = pathShareButtonMarkup(path);
+			if (shareButton) { buttons.push(shareButton); }
 			// Community "Änderung vorschlagen" -- paths get a public action band here for the first time.
 			const suggestSpec = typeof buildSuggestChangeButtonSpec === "function"
 				? buildSuggestChangeButtonSpec({
@@ -128,7 +131,7 @@ function createPathPopupMarkup(path) {
 				}));
 			}
 			return buttons.length ? locationPopupActionsMarkup(buttons) : "";
-		})() + pathShareMarkup(path) + pathWikiInfoboxMarkup(path),
+		})() + pathWikiInfoboxMarkup(path),
 	});
 }
 

--- a/js/map-features/map-features-region-info-markup.js
+++ b/js/map-features/map-features-region-info-markup.js
@@ -95,7 +95,9 @@ function createRegionWikiInfoBoxMarkup(regionEntry) {
 	const shareButton = wikiUrl
 		? sharePlaceActionButtonMarkup(regionEntry.publicId, { wikiUrl, wikiParam: regionWikiParam })
 		: "";
-	const shareMarkup = shareButton ? locationPopupActionsMarkup([shareButton]) : "";
+	const suggestSpec = typeof buildSuggestChangeButtonSpec === "function" ? buildSuggestChangeButtonSpec({ entityType: regionEntry.source === "political_territory" ? "territory" : "region", entityId: regionEntry.territoryPublicId || regionEntry.publicId || "", name, reportType: regionEntry.source === "political_territory" ? "territorium" : "region", label: tr("popup.suggestChange", "Änderung vorschlagen") }) : null;
+	const suggestButton = suggestSpec ? popupActionButtonMarkup(suggestSpec) : "";
+	const shareMarkup = (shareButton || suggestButton) ? locationPopupActionsMarkup([shareButton, suggestButton].filter(Boolean)) : "";
 	const wikiRows = [
 		createRegionInfoTextRow(tr("infobox.wikiEntry", "Wiki-Eintrag"), wikiName),
 		createRegionInfoTextRow(tr("infobox.status", "Status"), regionEntry.status || f.status),


### PR DESCRIPTION
Unifies the infopanel action band so **[Link teilen] [Änderung vorschlagen]** sit together in ONE tile band directly under the header, across all element types (matching the settlement layout).

- **Paths/rivers:** the share button ("Link teilen") moves into the same band as "Änderung vorschlagen" — previously it was a separate band two dividers below. (`pathShareMarkup` → `pathShareButtonMarkup`, folded into the band; the separate append is dropped.)
- **Regions/territories:** "Änderung vorschlagen" moves from the very bottom into the header share band (`createRegionWikiInfoBoxMarkup`).
- **No-wiki mini regions:** keep the button appended at the bottom (they render a compact box with no header action band).
- **Settlements:** unchanged (already correct).

Verified: `node --check` on all changed files. Visual layout to be confirmed on the live site by the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)