### PR TITLE
ui(infopanel): "Änderung vorschlagen" for regions (landscape labels)

### DIFF
--- a/js/map-features/map-features-labels.js
+++ b/js/map-features/map-features-labels.js
@@ -358,7 +358,7 @@ function buildRegionLabelViewPopupHtml(label) {
 		showWikiLink: false,
 		// "Link teilen" (Owner) direkt unter dem Kopf, die Landschafts-Infobox (Lage/Staat/Beschreibung +
 		// Quelle) darunter -- gleiche Anordnung wie Siedlung/Territorium/Weg.
-		actionsMarkup: locationPopupActionsMarkup([sharePlaceActionButtonMarkup(label.publicId, { wikiUrl: (label.wikiRegion && label.wikiRegion.wiki_url) || "", wikiParam: "region" })].filter(Boolean))
+		actionsMarkup: locationPopupActionsMarkup([sharePlaceActionButtonMarkup(label.publicId, { wikiUrl: (label.wikiRegion && label.wikiRegion.wiki_url) || "", wikiParam: "region" }), (function () { var s = typeof buildSuggestChangeButtonSpec === "function" ? buildSuggestChangeButtonSpec({ entityType: "region", entityId: label.publicId, name: labelName, reportType: "region", label: tr("popup.suggestChange", "Änderung vorschlagen") }) : null; return s ? popupActionButtonMarkup(s) : ""; })()].filter(Boolean))
 			+ labelWikiInfoboxMarkup(label, { headless: true }),
 	});
 }


### PR DESCRIPTION
Geographic regions render as wiki-region **labels** via `buildRegionLabelViewPopupHtml` (their `labelActionsMarkup` is edit-only), so they had no public action band and the suggest-change button never appeared. This adds the button next to "Link teilen" in the label's header band — same layout as settlements / paths / territories.

One-line change. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)